### PR TITLE
update logging with timestamp and filename

### DIFF
--- a/library/simulation/telemetry_sim.py
+++ b/library/simulation/telemetry_sim.py
@@ -1,17 +1,26 @@
+"""
+Copyright MIT
+GNU General Public License v3.0
+
+BWSI Autonomous RACECAR Course
+Racecar Neo LTS
+
+File Name: telemetry_sim.py
+File Description: Contains the Telemetry simulation module of the racecar_core library.
+"""
+
 import time
 
 import pandas as pd
 from matplotlib import pyplot as plt
-from telemetry import Telemetry
+from telemetry import Telemetry, _resolve_log_paths
 
 
 class TelemetrySim(Telemetry):
 
-    _LOG_FILE_NAME = "log.csv"
-    _PLOT_FILE_NAME = "log.png"
-
     def __init__(self) -> None:
         self.variable_names = None
+        self._LOG_FILE_NAME, self._PLOT_FILE_NAME = _resolve_log_paths()
         self.log_file = open(self._LOG_FILE_NAME, "w+")
         self.start_time = time.time()
 
@@ -34,7 +43,7 @@ class TelemetrySim(Telemetry):
         if self.variable_names is None:
             return
 
-        # Seek to beginning of file before reading, 
+        # Seek to beginning of file before reading,
         # then seek to the end afterwards in case we want to write more data
         self.log_file.seek(0)
         frame = pd.read_csv(self.log_file)
@@ -47,6 +56,6 @@ class TelemetrySim(Telemetry):
             if variable != "time":
                 ax.plot(frame["time"], frame[variable], label=variable)
         ax.legend()
-        
+
         plt.savefig(self._PLOT_FILE_NAME)
         self.log_file.seek(0, 2)

--- a/library/telemetry.py
+++ b/library/telemetry.py
@@ -1,6 +1,6 @@
 """
 Copyright MIT
-MIT License
+GNU General Public License v3.0
 
 BWSI Autonomous RACECAR Course
 Racecar Neo LTS
@@ -10,6 +10,48 @@ File Description: Defines the interface of the Telemetry module of the racecar_c
 """
 
 import abc
+import os
+import re
+import sys
+import time
+
+
+def _resolve_log_paths() -> tuple[str, str]:
+    """
+    Build the CSV and PNG log paths inside racecar-student/labs/logs/.
+
+    Filename format: YYYYMMDD_HHMMSS_<calling_file_stem>.{csv,png}, where the
+    timestamp is wall-clock local time on the student's machine. Creates the
+    logs/ folder on first use.
+    """
+    # labs/ lives at <library_root>/../labs/, regardless of which racecar-venv or
+    # CWD the student runs from. __file__ is racecar-student/library/telemetry.py.
+    library_dir = os.path.dirname(os.path.abspath(__file__))
+    labs_dir = os.path.abspath(os.path.join(library_dir, "..", "labs"))
+    logs_dir = os.path.join(labs_dir, "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+
+    # Identify what produced the log. .py scripts give us argv[0]; notebooks
+    # leak their path through __vsc_ipynb_file__ (VS Code) or JPY_SESSION_NAME.
+    stem = "interactive"
+    argv0 = sys.argv[0] if sys.argv else ""
+    main_mod = sys.modules.get("__main__")
+    nb_path = getattr(main_mod, "__vsc_ipynb_file__", None) or os.environ.get("JPY_SESSION_NAME")
+    if nb_path:
+        stem = os.path.splitext(os.path.basename(nb_path))[0]
+    elif argv0 and not argv0.endswith(("ipykernel_launcher.py", "kernel.py")):
+        base = os.path.basename(argv0)
+        if base:
+            stem = os.path.splitext(base)[0]
+    elif "ipykernel" in sys.modules:
+        stem = "notebook"
+
+    # Strip anything that would make the filename awkward on Windows/macOS.
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "_", stem).strip("._-") or "log"
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    base = f"{timestamp}_{stem}"
+    return os.path.join(logs_dir, base + ".csv"), os.path.join(logs_dir, base + ".png")
 
 
 class Telemetry(abc.ABC):


### PR DESCRIPTION
Ports [MITUavNeo/uav-neo-library#3](https://github.com/MITUavNeo/uav-neo-library/pull/3).

## Behavior change

Old: every `TelemetrySim()` init opened `log.csv` (and later `log.png`) in the cwd, overwriting prior runs and spamming whatever directory the student happened to be running from.

New: each run writes to `racecar-student/labs/logs/<YYYYMMDD_HHMMSS>_<scriptname>.{csv,png}`. Multiple runs accumulate, the location is predictable and discoverable, and cwd stays clean.

## Implementation

- New `_resolve_log_paths()` helper in [library/telemetry.py](library/telemetry.py) — resolves `labs/` relative to `__file__` (sibling of `library/`), so it works regardless of cwd or whether the shell sourced `.config`. Auto-creates `logs/` on first call.
- Filename stem detection: `argv[0]` for `.py` scripts; `__vsc_ipynb_file__` (VS Code) and `JPY_SESSION_NAME` (plain Jupyter) for notebooks; `interactive` / `notebook` fallbacks otherwise. Sanitized against Windows/macOS-hostile characters.
- [library/simulation/telemetry_sim.py](library/simulation/telemetry_sim.py) — `__init__` now calls the helper instead of using hardcoded class-level `_LOG_FILE_NAME`/`_PLOT_FILE_NAME` constants. No other behavioral changes; class API surface unchanged.